### PR TITLE
allow to configure the role_arn for logstash-output-kinesis

### DIFF
--- a/runtime/etc/init/logstash.conf
+++ b/runtime/etc/init/logstash.conf
@@ -22,6 +22,7 @@ script
     instanceRegion=$(echo ${instanceAvailabilityZone} | rev | cut -c 2- | rev)
     region=$(cat /meta/taupage.yaml | shyaml get-value "logstash.kinesis_region" "${instanceRegion}")
     stream=$(cat /meta/taupage.yaml | shyaml get-value "logstash.kinesis_stream" "logging")
+    role_arn=$(cat /meta/taupage.yaml | shyaml get-value "logstash.kinesis_role_arn" "none")
     debug=$(cat /meta/taupage.yaml | shyaml get-value "logstash.debug" "false")
     
     rm -rf /etc/logstash.conf
@@ -106,6 +107,7 @@ cat <<__EOF >> /etc/logstash.conf
     # https://github.com/samcday/logstash-output-kinesis
     kinesis {
       stream_name => "${stream}"
+      role_arn => "${role_arn}"
       region => "${region}"
       # for more settings see
       # https://github.com/awslabs/amazon-kinesis-producer/blob/v0.10.0/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java#L230


### PR DESCRIPTION
@nmohaupt @thoeynck die Änderung um das logstash-output-kinesis Plugin mit einer RoleARN zu versehen.

Ich vermute, dass es funktioniert, aber hierfür gibt es so null tests(?)
